### PR TITLE
bw/BUG-322 Django Enquiry/job admin page shows only N -1 history elements

### DIFF
--- a/django_admin_bootstrapped/templates/admin/edit_inline/tabular.html
+++ b/django_admin_bootstrapped/templates/admin/edit_inline/tabular.html
@@ -28,7 +28,7 @@
         <tr><td colspan="{{ inline_admin_form|cell_count }}"><div class="alert alert-danger">
 {{ inline_admin_form.form.non_field_errors }}</div></td></tr>
         {% endif %}
-        <tr class="form-row {% cycle "row1" "row2" %} {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last %} empty-form{% endif %}"
+        <tr class="form-row {% cycle "row1" "row2" %} {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
              id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
         <td class="original">
           {% if inline_admin_formset.opts.sortable_field_name %}


### PR DESCRIPTION
Prevent from adding `empty-form` css class to the last row in the table.
The class' `disaplay` value is `none` therefor it looks like the list
is shorter with one element that it should be.

Once the fix is merged a tag `2.5.7p2` will be created and the 
`requirements/base.txt` will refer to the tag.

https://plentific.atlassian.net/browse/BUG-322